### PR TITLE
Add getById and removeById.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## 3.0.0 - 2021-XX-XX
 
 ### Changed
-- **BREAKING**: `restrictions.get` now returns the `restrictions` property
-  with an array of all restrictions matching the `zone` and `resource`.
+- **BREAKING**: `restrictions.get()` now takes an `id` parameter, instead of
+  `zone` and `resource`.
 
 ### Added
-- Added `getById` and `removeById` to `restrictions`.
+- Added `getAll()` and `removeById()` to `restrictions`.
 
 ## 2.0.0 - 2021-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # bedrock-resource-restriction ChangeLog
 
+## 3.0.0 - 2021-XX-XX
+
+### Changed
+- **BREAKING**: `restrictions.get` now returns an array instead of an object.
+
+### Added
+- Added `getById` and `removeById` to `restrictions`.
+
 ## 2.0.0 - 2021-03-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Changed
 - **BREAKING**: `restrictions.get()` now takes an `id` parameter, instead of
   `zone` and `resource`.
+- **BREAKING**: `restrictions.remove()` now takes an `id` parameter, instead of
+  `zone` and `resource`.
 
 ### Added
-- Added `getAll()` and `removeById()` to `restrictions`.
+- Added `getAll()` and `removeAll()` to `restrictions`.
 
 ## 2.0.0 - 2021-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 3.0.0 - 2021-XX-XX
 
 ### Changed
-- **BREAKING**: `restrictions.get` now returns an array instead of an object.
+- **BREAKING**: `restrictions.get` now returns the `restrictions` property
+  with an array of all restrictions matching the `zone` and `resource`.
 
 ### Added
 - Added `getById` and `removeById` to `restrictions`.

--- a/lib/restrictions.js
+++ b/lib/restrictions.js
@@ -148,7 +148,7 @@ export async function update({restriction} = {}) {
 }
 
 /**
- * Gets a restriction given a zone ID and a resource ID.
+ * Gets restrictions given a zone ID and a resource ID.
  *
  * @param {object} options - Options to use.
  * @param {string} options.zone - The ID of the zone that the
@@ -156,7 +156,8 @@ export async function update({restriction} = {}) {
  * @param {string} options.resource - The ID of the resource that the
  *   restriction applies to.
  *
- * @returns {Promise<object>} An object with the record.
+ * @returns {Promise<object>} An object with the `restrictions` property which
+ *   is an array of matching records.
  */
 export async function get({zone, resource} = {}) {
   const query = {

--- a/lib/restrictions.js
+++ b/lib/restrictions.js
@@ -127,8 +127,7 @@ export async function bulkInsert({restrictions} = {}) {
  */
 export async function update({restriction} = {}) {
   const query = {
-    'restriction.zone': restriction.zone,
-    'restriction.resource': restriction.resource
+    'restriction.id': restriction.id
   };
   const collection = database.collections['resource-restriction-restriction'];
   const $set = {
@@ -166,6 +165,33 @@ export async function get({zone, resource} = {}) {
   };
   const projection = {_id: 0};
   const collection = database.collections['resource-restriction-restriction'];
+  const records = await collection.find(query, {projection}).toArray();
+  if(records.length === 0) {
+    const details = {
+      httpStatusCode: 404,
+      public: true
+    };
+    throw new BedrockError(
+      'Restriction not found.',
+      'NotFoundError', details);
+  }
+  return records;
+}
+
+/**
+ * Gets a restriction given a restriction ID.
+ *
+ * @param {object} options - Options to use.
+ * @param {string} options.id - The ID of the restriction.
+ *
+ * @returns {Promise<object>} An object with the record.
+ */
+export async function getById({id}) {
+  const query = {
+    'restriction.id': id
+  };
+  const projection = {_id: 0};
+  const collection = database.collections['resource-restriction-restriction'];
   const record = await collection.findOne(query, {projection});
   if(!record) {
     const details = {
@@ -194,6 +220,22 @@ export async function remove({zone, resource} = {}) {
   const query = {
     'restriction.zone': zone,
     'restriction.resource': resource
+  };
+  const collection = database.collections['resource-restriction-restriction'];
+  await collection.deleteMany(query);
+}
+
+/**
+ * Deletes a restriction from the database by ID.
+ *
+ * @param {object} options - The options to use.
+ * @param {string} options.id - The ID of restriction.
+ *
+ * @returns {Promise} - Settles once the operation completes.
+ */
+export async function removeById({id}) {
+  const query = {
+    'restriction.id': id
   };
   const collection = database.collections['resource-restriction-restriction'];
   await collection.deleteOne(query);

--- a/lib/restrictions.js
+++ b/lib/restrictions.js
@@ -148,7 +148,34 @@ export async function update({restriction} = {}) {
 }
 
 /**
- * Gets restrictions given a zone ID and a resource ID.
+ * Gets a restriction given a restriction ID.
+ *
+ * @param {object} options - Options to use.
+ * @param {string} options.id - The ID of the restriction.
+ *
+ * @returns {Promise<object>} An object with the record.
+ */
+export async function get({id} = {}) {
+  const query = {
+    'restriction.id': id
+  };
+  const projection = {_id: 0};
+  const collection = database.collections['resource-restriction-restriction'];
+  const record = await collection.findOne(query, {projection});
+  if(!record) {
+    const details = {
+      httpStatusCode: 404,
+      public: true
+    };
+    throw new BedrockError(
+      'Restriction not found.',
+      'NotFoundError', details);
+  }
+  return record;
+}
+
+/**
+* Gets restrictions given a zone ID and a resource ID.
  *
  * @param {object} options - Options to use.
  * @param {string} options.zone - The ID of the zone that the
@@ -159,7 +186,8 @@ export async function update({restriction} = {}) {
  * @returns {Promise<object>} An object with the `restrictions` property which
  *   is an array of matching records.
  */
-export async function get({zone, resource} = {}) {
+export async function getAll({zone, resource}) {
+
   const query = {
     'restriction.zone': zone,
     'restriction.resource': resource
@@ -177,33 +205,6 @@ export async function get({zone, resource} = {}) {
       'NotFoundError', details);
   }
   return {restrictions: records};
-}
-
-/**
- * Gets a restriction given a restriction ID.
- *
- * @param {object} options - Options to use.
- * @param {string} options.id - The ID of the restriction.
- *
- * @returns {Promise<object>} An object with the record.
- */
-export async function getById({id}) {
-  const query = {
-    'restriction.id': id
-  };
-  const projection = {_id: 0};
-  const collection = database.collections['resource-restriction-restriction'];
-  const record = await collection.findOne(query, {projection});
-  if(!record) {
-    const details = {
-      httpStatusCode: 404,
-      public: true
-    };
-    throw new BedrockError(
-      'Restriction not found.',
-      'NotFoundError', details);
-  }
-  return record;
 }
 
 /**

--- a/lib/restrictions.js
+++ b/lib/restrictions.js
@@ -187,7 +187,6 @@ export async function get({id} = {}) {
  *   is an array of matching records.
  */
 export async function getAll({zone, resource}) {
-
   const query = {
     'restriction.zone': zone,
     'restriction.resource': resource

--- a/lib/restrictions.js
+++ b/lib/restrictions.js
@@ -186,7 +186,7 @@ export async function get({id} = {}) {
  * @returns {Promise<object>} An object with the `restrictions` property which
  *   is an array of matching records.
  */
-export async function getAll({zone, resource}) {
+export async function getAll({zone, resource} = {}) {
   const query = {
     'restriction.zone': zone,
     'restriction.resource': resource
@@ -195,7 +195,9 @@ export async function getAll({zone, resource}) {
   const collection = database.collections['resource-restriction-restriction'];
   const records = await collection.find(query, {projection}).toArray();
 
-  return records;
+  const restrictions = records.map(record => record.restriction);
+
+  return {restrictions};
 }
 
 /**

--- a/lib/restrictions.js
+++ b/lib/restrictions.js
@@ -175,7 +175,7 @@ export async function get({zone, resource} = {}) {
       'Restriction not found.',
       'NotFoundError', details);
   }
-  return records;
+  return {restrictions: records};
 }
 
 /**

--- a/lib/restrictions.js
+++ b/lib/restrictions.js
@@ -217,7 +217,7 @@ export async function getAll({zone, resource}) {
  *
  * @returns {Promise} - Settles once the operation completes.
  */
-export async function remove({zone, resource} = {}) {
+export async function removeAll({zone, resource} = {}) {
   const query = {
     'restriction.zone': zone,
     'restriction.resource': resource
@@ -234,7 +234,7 @@ export async function remove({zone, resource} = {}) {
  *
  * @returns {Promise} - Settles once the operation completes.
  */
-export async function removeById({id}) {
+export async function remove({id}) {
   const query = {
     'restriction.id': id
   };

--- a/lib/restrictions.js
+++ b/lib/restrictions.js
@@ -194,16 +194,8 @@ export async function getAll({zone, resource}) {
   const projection = {_id: 0};
   const collection = database.collections['resource-restriction-restriction'];
   const records = await collection.find(query, {projection}).toArray();
-  if(records.length === 0) {
-    const details = {
-      httpStatusCode: 404,
-      public: true
-    };
-    throw new BedrockError(
-      'Restriction not found.',
-      'NotFoundError', details);
-  }
-  return {restrictions: records};
+
+  return records;
 }
 
 /**

--- a/test/mocha/10-restrictions.js
+++ b/test/mocha/10-restrictions.js
@@ -205,9 +205,9 @@ describe('restrictions', function() {
       resource: RESOURCES.MANGO
     });
     should.exist(restrictionsArray);
-    restrictionsArray.restrictions.length.should.equal(2);
-    restrictionsArray.restrictions[0].restriction.should.eql(mockRestriction1);
-    restrictionsArray.restrictions[1].restriction.should.eql(mockRestriction2);
+    restrictionsArray.should.be.an('array');
+    restrictionsArray.length.should.equal(2);
+    restrictionsArray[0].should.have.keys('restriction', 'meta');
   });
 
   it('should get zero restrictions that match a request', async function() {
@@ -377,9 +377,9 @@ describe('restrictions', function() {
       resource: RESOURCES.ASPARAGUS
     });
     should.exist(restrictionsArray);
-    restrictionsArray.restrictions.length.should.equal(2);
-    restrictionsArray.restrictions[0].restriction.should.eql(mockRestriction1);
-    restrictionsArray.restrictions[1].restriction.should.eql(mockRestriction2);
+    restrictionsArray.should.be.an('array');
+    restrictionsArray.length.should.equal(2);
+    restrictionsArray[0].should.have.keys('restriction', 'meta');
 
     // remove the restriction
     await restrictions.removeAll({
@@ -389,7 +389,7 @@ describe('restrictions', function() {
     let restrictionsArray2;
     let err;
     try {
-      // try getting the removed restriction, this should throw a NotFoundError
+      // try getting the removed restriction, this should return an empty array
       restrictionsArray2 = await restrictions.getAll({
         zone: ZONES.ONE,
         resource: RESOURCES.ASPARAGUS
@@ -397,10 +397,10 @@ describe('restrictions', function() {
     } catch(e) {
       err = e;
     }
-    should.not.exist(restrictionsArray2);
-    should.exist(err);
-    err.name.should.equal('NotFoundError');
-    err.message.should.equal('Restriction not found.');
+    should.not.exist(err);
+    should.exist(restrictionsArray2);
+    restrictionsArray2.should.be.an('array');
+    restrictionsArray2.length.should.equal(0);
   });
 
   it('should remove a restriction from the database by id', async function() {

--- a/test/mocha/10-restrictions.js
+++ b/test/mocha/10-restrictions.js
@@ -168,7 +168,7 @@ describe('restrictions', function() {
         }
       }
     });
-    const getRestriction = await restrictions.getById({id});
+    const getRestriction = await restrictions.get({id});
     const expectedRestriction = {
       id,
       zone: ZONES.TWO,
@@ -188,7 +188,7 @@ describe('restrictions', function() {
   });
 
   it('should get a restriction', async function() {
-    const getRestrictions = await restrictions.get({
+    const getRestrictions = await restrictions.getAll({
       zone: ZONES.ONE,
       resource: RESOURCES.KIWI
     });
@@ -374,7 +374,7 @@ describe('restrictions', function() {
     should.exist(actualRestriction.restriction);
     actualRestriction.restriction.should.deep.equal(expectedRestriction);
 
-    const getRestrictions = await restrictions.get({
+    const getRestrictions = await restrictions.getAll({
       zone: ZONES.ONE,
       resource: RESOURCES.MANGO
     });
@@ -393,10 +393,7 @@ describe('restrictions', function() {
     let err;
     try {
       // try getting the removed restriction, this should throw a NotFoundError
-      getRestriction2 = await restrictions.get({
-        zone: ZONES.ONE,
-        resource: RESOURCES.MANGO
-      });
+      getRestriction2 = await restrictions.get({id});
     } catch(e) {
       err = e;
     }
@@ -436,7 +433,7 @@ describe('restrictions', function() {
     should.exist(actualRestriction.restriction);
     actualRestriction.restriction.should.deep.equal(expectedRestriction);
 
-    const getRestrictions = await restrictions.get({
+    const getRestrictions = await restrictions.getAll({
       zone: ZONES.ONE,
       resource: RESOURCES.MANGO
     });
@@ -452,10 +449,7 @@ describe('restrictions', function() {
     let err;
     try {
       // try getting the removed restriction, this should throw a NotFoundError
-      getRestriction2 = await restrictions.get({
-        zone: ZONES.ONE,
-        resource: RESOURCES.MANGO
-      });
+      getRestriction2 = await restrictions.get({id});
     } catch(e) {
       err = e;
     }

--- a/test/mocha/10-restrictions.js
+++ b/test/mocha/10-restrictions.js
@@ -205,9 +205,11 @@ describe('restrictions', function() {
       resource: RESOURCES.MANGO
     });
     should.exist(restrictionsArray);
-    restrictionsArray.should.be.an('array');
-    restrictionsArray.length.should.equal(2);
-    restrictionsArray[0].should.have.keys('restriction', 'meta');
+    restrictionsArray.restrictions.should.be.an('array');
+    restrictionsArray.restrictions.length.should.equal(2);
+    restrictionsArray.restrictions.should.have.deep.members(
+      [mockRestriction1, mockRestriction2]
+    );
   });
 
   it('should get zero restrictions that match a request', async function() {
@@ -377,9 +379,11 @@ describe('restrictions', function() {
       resource: RESOURCES.ASPARAGUS
     });
     should.exist(restrictionsArray);
-    restrictionsArray.should.be.an('array');
-    restrictionsArray.length.should.equal(2);
-    restrictionsArray[0].should.have.keys('restriction', 'meta');
+    restrictionsArray.restrictions.should.be.an('array');
+    restrictionsArray.restrictions.length.should.equal(2);
+    restrictionsArray.restrictions.should.have.deep.members(
+      [mockRestriction1, mockRestriction2]
+    );
 
     // remove the restriction
     await restrictions.removeAll({
@@ -399,8 +403,8 @@ describe('restrictions', function() {
     }
     should.not.exist(err);
     should.exist(restrictionsArray2);
-    restrictionsArray2.should.be.an('array');
-    restrictionsArray2.length.should.equal(0);
+    restrictionsArray2.restrictions.should.be.an('array');
+    restrictionsArray2.restrictions.length.should.equal(0);
   });
 
   it('should remove a restriction from the database by id', async function() {

--- a/test/mocha/10-restrictions.js
+++ b/test/mocha/10-restrictions.js
@@ -154,7 +154,7 @@ describe('restrictions', function() {
       secondRestriction.restriction.methodOptions.duration.should.equal('P30D');
     });
 
-  it('should get a restriction', async function() {
+  it('should get a restriction by id', async function() {
     const id = await generateId();
     await restrictions.insert({
       restriction: {
@@ -187,7 +187,7 @@ describe('restrictions', function() {
     getRestriction.restriction.should.deep.equal(expectedRestriction);
   });
 
-  it('should get a restriction by id', async function() {
+  it('should get a restriction', async function() {
     const getRestrictions = await restrictions.get({
       zone: ZONES.ONE,
       resource: RESOURCES.KIWI
@@ -201,7 +201,7 @@ describe('restrictions', function() {
         duration: 'P30D'
       }
     };
-    const getRestriction = getRestrictions[0];
+    const getRestriction = getRestrictions.restrictions[0];
     should.exist(getRestriction);
     should.exist(getRestriction.meta);
     should.exist(getRestriction.restriction);
@@ -378,7 +378,7 @@ describe('restrictions', function() {
       zone: ZONES.ONE,
       resource: RESOURCES.MANGO
     });
-    const getRestriction = getRestrictions[0];
+    const getRestriction = getRestrictions.restrictions[0];
     should.exist(getRestriction);
     should.exist(getRestriction.meta);
     should.exist(getRestriction.restriction);
@@ -440,7 +440,7 @@ describe('restrictions', function() {
       zone: ZONES.ONE,
       resource: RESOURCES.MANGO
     });
-    const getRestriction = getRestrictions[0];
+    const getRestriction = getRestrictions.restrictions[0];
     should.exist(getRestriction);
     should.exist(getRestriction.meta);
     should.exist(getRestriction.restriction);

--- a/test/mocha/20-resources.js
+++ b/test/mocha/20-resources.js
@@ -231,11 +231,25 @@ describe('resources', function() {
     });
 
   it('should acquire with updated restriction', async function() {
+    const id = await generateId();
+    await restrictions.insert({
+      restriction: {
+        id,
+        zone: ZONES.ONE,
+        resource: RESOURCES.ASPARAGUS,
+        method: 'limitOverDuration',
+        methodOptions: {
+          limit: 1,
+          duration: 'P30D'
+        }
+      }
+    });
     // change restriction to allow additional acquisition
     await restrictions.update({
       restriction: {
+        id,
         zone: ZONES.ONE,
-        resource: RESOURCES.ORANGE,
+        resource: RESOURCES.ASPARAGUS,
         method: 'limitOverDuration',
         methodOptions: {
           limit: 2,
@@ -246,7 +260,7 @@ describe('resources', function() {
     const now = Date.now();
     const acquirerId = ACQUIRER_ID;
     const request = [
-      {resource: RESOURCES.ORANGE, count: 1, requested: now}
+      {resource: RESOURCES.ASPARAGUS, count: 2, requested: now}
     ];
     const acquisitionTtl = 30000;
     const zones = [ZONES.ONE, ZONES.TWO];

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -21,6 +21,7 @@ exports.RESOURCES = {
   MANGO: uuid(),
   STRAWBERRY: uuid(),
   CUCUMBER: uuid(),
+  ASPARAGUS: uuid(),
   LIME: uuid()
 };
 


### PR DESCRIPTION
- `restrictions.get`, which has `zone` and `resource` as parameters now returns an array instead of an object, since uniqueness of restrictions is now based off of `id`.
- Added `restrictions.getById` and `restrictions.removeById` which query off the restriction `id`.
- Changed `restrictions.remove`, which has `zone` and `resource` as parameters, to `deleteMany`
- `restrictions.update` now queries off `id` instead of `zone` and `resource`, however the entire `restriction` is passed into the function so there are no external changes to be made.