### PR TITLE
Update `expires` to Date Object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-resource-restriction ChangeLog
 
+## 4.0.0 - 2021-xx-xx
+
+### Changed
+- **BREAKING**: Updated property `expires` in `resource-restriction-acquisition`
+  table from seconds since the epoch to a Date Object.
+
 ## 3.0.0 - 2021-05-06
 
 ### Changed

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -315,6 +315,9 @@ async function _getAcquisitionRecord({acquirerId}) {
       }
     };
   }
+  if(record.acquisition.expires) {
+    record.acquisition.expires = record.acquisition.expires.getTime();
+  }
   return record;
 }
 
@@ -336,10 +339,11 @@ async function _updateAcquisitionRecord(
     'acquisition.tokenized': tokenized
   };
   const now = Date.now();
+  const expirationDate = new Date(expires);
   const $set = {
     'meta.updated': now,
     'acquisition.tokenized': newTokenized,
-    'acquisition.expires': expires
+    'acquisition.expires': expirationDate
   };
   const update = {$set};
   let dbOptions;


### PR DESCRIPTION
If the value of `expires` is undefined, the Date Object is set to 1970/01/01 and is inserted into the database then removed by the mongo expiration process.